### PR TITLE
Service Accounts

### DIFF
--- a/searchconsole/account.py
+++ b/searchconsole/account.py
@@ -54,10 +54,11 @@ class Account:
         return web_property
 
     def __repr__(self):
-        return "<searchconsole.account.Account(client_id='{}')>".format(
-            self.credentials.client_id
-        )
-
+        if hasattr(self.credentials, 'client_id'):
+            repr_str = "client_id='{}'".format(self.credentials.client_id)
+        else:
+            repr_str = "email='{}'".format(self.credentials.signer_email)
+        return "<searchconsole.account.Account({})>".format(repr_str)
 
 class WebProperty:
     """

--- a/searchconsole/auth.py
+++ b/searchconsole/auth.py
@@ -22,7 +22,7 @@ from .account import Account
 
 
 def authenticate(client_config=None, credentials=None, service_account=None,
-                 serialize=None):
+                 user_email=None, serialize=None):
     """
     The `authenticate` function will authenticate a user with the Google Search
     Console API.
@@ -34,6 +34,8 @@ def authenticate(client_config=None, credentials=None, service_account=None,
             parameters in the Google format specified in the module docstring
         service_account (collections.abc.Mapping or str): Path OAuth2 service
             account credentials.
+        user_email (str): The email address of the user to for which to
+            request delegated access when using a service account.
         serialize (str): Path to where credentials should be serialized.
 
     Returns:
@@ -89,14 +91,23 @@ def authenticate(client_config=None, credentials=None, service_account=None,
 
     elif service_account:
 
-        if isinstance(service_account, str):
+        if subject:
 
-            with open(service_account, 'r') as f:
-                service_account = json.load(f)
+            if isinstance(service_account, str):
 
-        credentials = google.oauth2.service_account.Credentials.from_service_account_info(
-            info=service_account
-        )
+                with open(service_account, 'r') as f:
+                    service_account = json.load(f)
+
+            credentials = google.oauth2.service_account.Credentials.from_service_account_info(
+                info=service_account,
+                scopes=['https://www.googleapis.com/auth/webmasters.readonly'],
+                subject=user_email
+            )
+
+        else:
+
+            raise ValueError("If using a Service Account, you must provide the \
+                email address of a user with access to the web property(s).")
 
     else:
 

--- a/searchconsole/auth.py
+++ b/searchconsole/auth.py
@@ -91,7 +91,7 @@ def authenticate(client_config=None, credentials=None, service_account=None,
 
     elif service_account:
 
-        if subject:
+        if user_email:
 
             if isinstance(service_account, str):
 

--- a/searchconsole/auth.py
+++ b/searchconsole/auth.py
@@ -14,13 +14,15 @@ import collections.abc
 import json
 
 from apiclient import discovery
-from google.oauth2.credentials import Credentials
+import google.oauth2.credentials
+import google.oauth2.service_account
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 from .account import Account
 
 
-def authenticate(client_config, credentials=None, serialize=None):
+def authenticate(client_config=None, credentials=None, service_account=None,
+                 serialize=None):
     """
     The `authenticate` function will authenticate a user with the Google Search
     Console API.
@@ -30,6 +32,8 @@ def authenticate(client_config, credentials=None, serialize=None):
             parameters in the Google format specified in the module docstring.
         credentials (collections.abc.Mapping or str): OAuth2 credentials
             parameters in the Google format specified in the module docstring
+        service_account (collections.abc.Mapping or str): Path OAuth2 service
+            account credentials.
         serialize (str): Path to where credentials should be serialized.
 
     Returns:
@@ -44,7 +48,24 @@ def authenticate(client_config, credentials=None, serialize=None):
         ... )
     """
 
-    if not credentials:
+    if credentials:
+
+        if isinstance(credentials, str):
+
+            with open(credentials, 'r') as f:
+                credentials = json.load(f)
+
+        credentials = google.oauth2.credentials.Credentials(
+            token=credentials['token'],
+            refresh_token=credentials['refresh_token'],
+            id_token=credentials['id_token'],
+            token_uri=credentials['token_uri'],
+            client_id=credentials['client_id'],
+            client_secret=credentials['client_secret'],
+            scopes=credentials['scopes']
+        )
+
+    elif client_config and not (credentials or service_account):
 
         if isinstance(client_config, collections.abc.Mapping):
 
@@ -61,28 +82,26 @@ def authenticate(client_config, credentials=None, serialize=None):
             )
 
         else:
-
             raise ValueError("Client secrets must be a mapping or path to file")
 
         flow.run_local_server()
         credentials = flow.credentials
 
+    elif service_account:
+
+        if isinstance(service_account, str):
+
+            with open(service_account, 'r') as f:
+                service_account = json.load(f)
+
+        credentials = google.oauth2.service_account.Credentials.from_service_account_info(
+            info=service_account
+        )
+
     else:
 
-        if isinstance(credentials, str):
+        raise ValueError("Insufficient credentials provided.")
 
-            with open(credentials, 'r') as f:
-                credentials = json.load(f)
-
-        credentials = Credentials(
-            token=credentials['token'],
-            refresh_token=credentials['refresh_token'],
-            id_token=credentials['id_token'],
-            token_uri=credentials['token_uri'],
-            client_id=credentials['client_id'],
-            client_secret=credentials['client_secret'],
-            scopes=credentials['scopes']
-        )
 
     service = discovery.build(
         serviceName='webmasters',
@@ -92,24 +111,37 @@ def authenticate(client_config, credentials=None, serialize=None):
     )
 
     if serialize:
-
-        if isinstance(serialize, str):
-
-            serialized = {
-                'token': credentials.token,
-                'refresh_token': credentials.refresh_token,
-                'id_token': credentials.id_token,
-                'token_uri': credentials.token_uri,
-                'client_id': credentials.client_id,
-                'client_secret': credentials.client_secret,
-                'scopes': credentials.scopes
-            }
-
-            with open(serialize, 'w') as f:
-                json.dump(serialized, f)
-
-        else:
-
-            raise TypeError('`serialize` must be a path.')
+        serialize_credentials(credentials, serialize)
 
     return Account(service, credentials)
+
+
+def serialize_credentials(credentials, path):
+    """
+    Serialize credentials as JSON file.
+
+    Args:
+        credentials (`google.oauth2.credentials.Credentials`): Credentials object.
+        path (`str`): Path where serialized credentials should be stored.
+
+    Returns:
+        None
+    """
+    if isinstance(path, str):
+
+        serialized = {
+            'token': credentials.token,
+            'refresh_token': credentials.refresh_token,
+            'id_token': credentials.id_token,
+            'token_uri': credentials.token_uri,
+            'client_id': credentials.client_id,
+            'client_secret': credentials.client_secret,
+            'scopes': credentials.scopes
+        }
+
+        with open(path, 'w') as f:
+            json.dump(serialized, f)
+
+    else:
+
+        raise TypeError('`serialize` must be a path.')


### PR DESCRIPTION
I got this working using a service account. It requires you to delegate domain-wide authority to the service account, which requires you to have G Suite. The G Suite admin will need to add the Client ID  of the service account with the scope "https://www.googleapis.com/auth/webmasters.readonly".

After the service account is setup correctly, the code mostly worked as-is. I only added the scope and the user the service account is impersonating to the auth process. Compared to the existing quickstart example, I only changed line 2 to `account = searchconsole.authenticate(service_account='client_secrets.json', user_email='name@domain.com')` and the experience is identical, obviously excluding the interactive parts.