### PR TITLE
Updated service and version in auth.py to reflect upcoming Google API…

### DIFF
--- a/searchconsole/auth.py
+++ b/searchconsole/auth.py
@@ -93,8 +93,8 @@ def authenticate(client_config, credentials=None, serialize=None, flow="web"):
         )
 
     service = discovery.build(
-        serviceName='webmasters',
-        version='v3',
+        serviceName='searchconsole',
+        version='v1',
         credentials=credentials,
         cache_discovery=False,
     )


### PR DESCRIPTION
… changes

2 extra notes:

- did not add the `http=http` parameter from the Google example to the `discover.build()` call, as I believe if it's `None` then some http handler is generated anyway (language probably all wrong there)
- did not remove any existing parameters in that function call as Google seemed to say all other functionality will be the same