### PR TITLE
Fix Travis CI builds due to dependency conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: python
+env:
+  - VIRTUALENV_SEEDER=pip
 python: "3.6"
 before_install:
   - openssl aes-256-cbc -K $encrypted_1adc08e29f14_key -iv $encrypted_1adc08e29f14_iv -in auth.tar.enc -out auth.tar -d
   - tar xvf auth.tar
-install: python setup.py install
+install:
+  - pip uninstall -y six
+  - pip install six>=1.13.0
+  - python setup.py install
 script: python setup.py test
 sudo: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-google-api-python-client>=1.7.3'
-python-dateutil>=2.7.3'
-google-auth>=1.5.0'
+google-api-python-client>=1.7.3
+python-dateutil>=2.7.3
+google-auth>=1.5.0
 google-auth-oauthlib>=0.2.0


### PR DESCRIPTION
The CI builds were failing due to incorrect version pinning and
a dependency conflict with six. This change ensures a usable
version of six is used for running the tests.
